### PR TITLE
Bump dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1608910604,
-        "narHash": "sha256-kjTAJGPmfckaZGnn9ouPY/v07GKc9vOFlBesyWiCENU=",
+        "lastModified": 1631273642,
+        "narHash": "sha256-LeD8U6LijyPHgr5ECLk7cobb4EkgPyPJJjxcYNi8noo=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "5f5469b38da431a56889b5a06597be6c4808b345",
+        "rev": "1714a2ead1a18678afa3cbf75dff3f024c579061",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update nix dependencies, to keep them up to date.

Related issue: https://issues.serokell.io/issue/OPS-1269